### PR TITLE
Fixed AutomaticKit

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -87,7 +87,7 @@ uploadArchives {
 
 dependencies {
     compileOnly 'org.apache.commons:commons-lang3:3.11'
-    compileOnly 'LibsDisguises:LibsDisguises:10.0.21'
+    compileOnly 'LibsDisguises:LibsDisguises:10.0.23'
     compileOnly 'com.destroystokyo.paper:paper-api:1.16.5-R0.1-SNAPSHOT'
     compileOnly 'org.bukkit:craftbukkit:1.16.5-R0.1-SNAPSHOT'
     compileOnly 'de.hglabor:localization:0.0.6'

--- a/src/main/java/de/hglabor/plugins/kitapi/kit/kits/AutomaticKit.java
+++ b/src/main/java/de/hglabor/plugins/kitapi/kit/kits/AutomaticKit.java
@@ -5,8 +5,10 @@ import de.hglabor.plugins.kitapi.kit.AbstractKit;
 import de.hglabor.plugins.kitapi.kit.events.KitEvent;
 import de.hglabor.plugins.kitapi.kit.settings.DoubleArg;
 import de.hglabor.plugins.kitapi.player.KitPlayer;
+import de.hglabor.plugins.kitapi.pvp.SoupHealing;
 import de.hglabor.plugins.kitapi.util.Logger;
 import org.bukkit.Material;
+import org.bukkit.attribute.Attribute;
 import org.bukkit.entity.Player;
 import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.inventory.ItemStack;
@@ -28,22 +30,30 @@ public class AutomaticKit extends AbstractKit {
         KitPlayer kitPlayer = KitApi.getInstance().getPlayer(player);
         Logger.debug(String.format("%s %s", player.getName(), this.getName()));
         Logger.debug(String.format("%s is in inventory? %s", player.getName(), kitPlayer.isInInventory()));
-        if (kitPlayer.isInInventory()) return;
-        if (player.getHealth() < 14) {
-            for (int i = 1; i < 9; i++) {
-                ItemStack item = player.getInventory().getItem(i);
-                if (item == null) continue;
-                if (item.getType().equals(Material.MUSHROOM_STEW)) {
-                    if ((player.getHealth() + soupHealValue) > 20) {
-                        double difference = 20 - player.getHealth();
-                        player.setHealth(difference + player.getHealth());
-                    } else {
-                        player.setHealth(soupHealValue + player.getHealth());
-                    }
-                    item.setAmount(0);
-                    break;
-                }
+        if (kitPlayer.isInInventory()) {
+            return;
+        }
+        if (player.getHealth() >= 14) {
+            return;
+        }
+
+        /*
+         * Soup can also be in first slot
+         * There are actually people having their sword in
+         * another slot
+         */
+        for (int i = 0; i < 9; i++) {
+            ItemStack item = player.getInventory().getItem(i);
+            if (item == null) {
+                continue;
             }
+            if (!SoupHealing.SOUP_MATERIAL.contains(item.getType())) {
+                continue;
+            }
+            player.setHealth(Math.min(player.getHealth() + this.soupHealValue
+                    , player.getAttribute(Attribute.GENERIC_MAX_HEALTH).getValue()));
+            item.setAmount(0);
+            break;
         }
     }
 }

--- a/src/main/java/de/hglabor/plugins/kitapi/listener/InventoryDetection.java
+++ b/src/main/java/de/hglabor/plugins/kitapi/listener/InventoryDetection.java
@@ -5,13 +5,20 @@ import de.hglabor.plugins.kitapi.player.KitPlayer;
 import de.hglabor.plugins.kitapi.util.Logger;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryCloseEvent;
 
 public class InventoryDetection implements Listener {
 
-    @EventHandler
+    /*
+     * Could be triggered after choosing a kit in a gui
+     * So it could be set to true even if the selection
+     * menu closes the gui
+     * Priority always triggers the listener first
+     */
+    @EventHandler(priority = EventPriority.LOW)
     public void onInventoryClickEvent(InventoryClickEvent event) {
         KitPlayer kitPlayer = KitApi.getInstance().getPlayer((Player) event.getWhoClicked());
         Logger.debug(String.format("%s opened inventory", event.getWhoClicked().getName()));


### PR DESCRIPTION
- Improved priority of open inventory detection to prevent bugs
- Reformatted code of AutomaticKit
- also scan first slot
- Scan all materials
- Use better way to handle the max health
- Don't use deprecated code to get max health
(- Updated dependency to fix dependency issues)