### PR TITLE
Nerfed GravityKit

### DIFF
--- a/src/main/java/de/hglabor/plugins/kitapi/player/KitPlayer.java
+++ b/src/main/java/de/hglabor/plugins/kitapi/player/KitPlayer.java
@@ -32,7 +32,33 @@ public interface KitPlayer {
 
     boolean isValid();
 
-    boolean isInCombat();
+    /**
+     * Check if a player is in combat
+     * for specific amount of time
+     *
+     * @param combatTimeLimit The duration limit of the combat in seconds
+     * @return The result of the check
+     */
+    boolean isInCombat(int combatTimeLimit);
+
+    /**
+     * Added this method as default
+     * implementation calling the old declaring
+     * of this method to avoid compatibility issues with non-project classes
+     * using this interface
+     *
+     * Please remove and implement in sub-classes if possible
+     * Comment, create an issue or change this yourself if the only time this gets used
+     * is in {@see KitPlayerImpl}
+     * Disclaimer when changing: You may need to refactor every use of this method even
+     * outside this project
+     *
+     * @return The return of the check with default value
+     */
+    default boolean isInCombat() {
+        //Using default value and maximum of old isInCombat
+        return this.isInCombat(10);
+    }
 
     void disableKits(boolean shouldDisable);
 

--- a/src/main/java/de/hglabor/plugins/kitapi/player/KitPlayerImpl.java
+++ b/src/main/java/de/hglabor/plugins/kitapi/player/KitPlayerImpl.java
@@ -74,13 +74,13 @@ public abstract class KitPlayerImpl implements KitPlayer {
     public abstract boolean isValid();
 
     @Override
-    public boolean isInCombat() {
-        Optional<Player> lastDamager = lastHitInformation.getLastDamager();
-        if (lastDamager.isPresent()) {
-            KitPlayer damager = KitApi.getInstance().getPlayer(lastDamager.get());
-            return damager.isValid() && lastHitInformation.getLastDamagerTimestamp() + 10 * 1000L > System.currentTimeMillis();
+    public boolean isInCombat(int combatTimeLimit) {
+        Optional<Player> lastDamager = this.lastHitInformation.getLastDamager();
+        if (!lastDamager.isPresent()) {
+            return false;
         }
-        return false;
+        KitPlayer damager = KitApi.getInstance().getPlayer(lastDamager.get());
+        return damager.isValid() && lastHitInformation.getLastDamagerTimestamp() + combatTimeLimit * 1000L > System.currentTimeMillis();
     }
 
     @Override


### PR DESCRIPTION
**What do I want to achieve?**
Many gravity players run aways from a fight. I think this nerf will remove this problem, but the kit will still work fine.

**Changes:**
- Levitation effect will be shorter in combat
- Normal gravitation and combat gravitation can be configured now
- Max combat time can be configured for GravityKit
- The combat time is now a parameter in the check method
- default implementation with the old combat time added to avoid compatiblity issues (READ METHOD COMMENT IF YOU WANT TO CHANGE IT)

**Disclaimer:**
Please read the comment of the default implementation in `KitPlayer` before removing it if you ever do so!
