### PR TITLE
cleared LastHitInformation after the Player died

### DIFF
--- a/src/main/java/de/hglabor/plugins/kitapi/kit/events/KitEventHandlerImpl.java
+++ b/src/main/java/de/hglabor/plugins/kitapi/kit/events/KitEventHandlerImpl.java
@@ -121,6 +121,7 @@ public class KitEventHandlerImpl extends KitEventHandler implements Listener {
     @EventHandler
     public void onKitPlayerDeath(PlayerDeathEvent event) {
         KitPlayer kitPlayer = playerSupplier.getKitPlayer(event.getEntity());
+        kitPlayer.getLastHitInformation().clear();
         useKit(event, kitPlayer, kit -> kit.onKitPlayerDeath(event));
     }
 

--- a/src/main/java/de/hglabor/plugins/kitapi/pvp/LastHitInformation.java
+++ b/src/main/java/de/hglabor/plugins/kitapi/pvp/LastHitInformation.java
@@ -65,7 +65,7 @@ public class LastHitInformation {
         return lastDamagerTimestamp;
     }
 
-    private void clear() {
+    public void clear() {
         lastEntity = null;
         lastPlayer = null;
         lastDamager = null;


### PR DESCRIPTION
Hab das gecleared weil man sonst in Ffa nachdem man gestorben ist z.b. Grappler cooldown hat weil man noch im fight ist